### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/article/diff_initial_revised_1.bbl
+++ b/article/diff_initial_revised_1.bbl
@@ -5,7 +5,7 @@
 \def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@}
   {\mn@doi@[]}}
 \def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href
-  {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi
+  {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi
   \endgroup}
 \def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}
 \def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}

--- a/article/mnras.bst
+++ b/article/mnras.bst
@@ -1808,7 +1808,7 @@ FUNCTION {begin.bib}
 "\relax" write$ newline$
 "\def\mn@urlcharsother{\let\do\@makeother \do\$\do\&\do\#\do\^\do\_\do\%\do\~}" write$ newline$
 "\def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@} {\mn@doi@[]}}" write$ newline$
-"\def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi \endgroup}" write$ newline$
+"\def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi \endgroup}" write$ newline$
 "\def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}" write$ newline$
 "\def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}" write$ newline$
 "\def\mn@eprint@dblp#1{\href {http://dblp.uni-trier.de/rec/bibtex/#1.xml} {dblp:#1}}" write$ newline$

--- a/article/mnras.cls
+++ b/article/mnras.cls
@@ -1403,9 +1403,9 @@ $\reset@font\displaystyle##$\hfil\cr>\cr\approx\cr}}}
 \def\@doi[#1]#2{%
   \def\@tempa{#1}%
   \ifx\@tempa\@empty
-    \href{http://dx.doi.org/#2}{doi:#2}%
+    \href{https://doi.org/#2}{doi:#2}%
   \else
-    \href{http://dx.doi.org/#2}{#1}%
+    \href{https://doi.org/#2}{#1}%
   \fi
   \endgroup
   }

--- a/article/ms.bbl
+++ b/article/ms.bbl
@@ -5,7 +5,7 @@
 \def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@}
   {\mn@doi@[]}}
 \def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href
-  {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi
+  {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi
   \endgroup}
 \def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}
 \def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}

--- a/article/msarchive5feb2018.bbl
+++ b/article/msarchive5feb2018.bbl
@@ -5,7 +5,7 @@
 \def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@}
   {\mn@doi@[]}}
 \def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href
-  {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi
+  {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi
   \endgroup}
 \def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}
 \def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}

--- a/article/msculled.bbl
+++ b/article/msculled.bbl
@@ -5,7 +5,7 @@
 \def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@}
   {\mn@doi@[]}}
 \def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href
-  {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi
+  {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi
   \endgroup}
 \def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}
 \def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}

--- a/article/msculled_initial_submission.bbl
+++ b/article/msculled_initial_submission.bbl
@@ -5,7 +5,7 @@
 \def\mn@doi{\begingroup\mn@urlcharsother \@ifnextchar [ {\mn@doi@}
   {\mn@doi@[]}}
 \def\mn@doi@[#1]#2{\def\@tempa{#1}\ifx\@tempa\@empty \href
-  {http://dx.doi.org/#2} {doi:#2}\else \href {http://dx.doi.org/#2} {#1}\fi
+  {https://doi.org/#2} {doi:#2}\else \href {https://doi.org/#2} {#1}\fi
   \endgroup}
 \def\mn@eprint#1#2{\mn@eprint@#1:#2::\@nil}
 \def\mn@eprint@arXiv#1{\href {http://arxiv.org/abs/#1} {{\tt arXiv:#1}}}


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOI links and any code that hyperlinks DOIs.

Cheers!